### PR TITLE
Correct code for gcc-12.2.0, g++-12.2.0 under Linux-6.1.0-13-amd64, D…

### DIFF
--- a/src/platform/linux/system/Dispatcher.cpp
+++ b/src/platform/linux/system/Dispatcher.cpp
@@ -15,6 +15,12 @@
 #include <sys/timerfd.h>
 #include <ucontext.h>
 #include <unistd.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdexcept>
+#define PTHREAD_MUTEX_INITIALIZER { { 0, 0, 0, 0, 0, { 0 } } }
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 namespace System
 {

--- a/src/platform/linux/system/Dispatcher.h
+++ b/src/platform/linux/system/Dispatcher.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <queue>
 #include <stack>
+#include <cstdint>
 
 #ifndef __GLIBC__
 

--- a/src/platform/linux/system/TcpConnection.cpp
+++ b/src/platform/linux/system/TcpConnection.cpp
@@ -12,6 +12,7 @@
 #include <system/InterruptedException.h>
 #include <system/Ipv4Address.h>
 #include <unistd.h>
+#include <stdexcept>
 
 namespace System
 {

--- a/src/serialization/KVBinaryOutputStreamSerializer.cpp
+++ b/src/serialization/KVBinaryOutputStreamSerializer.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <common/StreamTools.h>
 #include <stdexcept>
+#include <limits>
 
 using namespace Common;
 using namespace CryptoNote;

--- a/src/serialization/SerializationOverloads.h
+++ b/src/serialization/SerializationOverloads.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <stdexcept>
 
 namespace CryptoNote
 {

--- a/src/transfers/BlockchainSynchronizer.cpp
+++ b/src/transfers/BlockchainSynchronizer.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_set>
+#include <thread>
 
 using namespace Common;
 using namespace Crypto;

--- a/src/zedwallet/Fusion.cpp
+++ b/src/zedwallet/Fusion.cpp
@@ -12,6 +12,7 @@
 #include <wallet/WalletGreen.h>
 #include <wallet/WalletUtils.h>
 #include <zedwallet/Tools.h>
+#include <thread>
 
 size_t makeFusionTransaction(CryptoNote::WalletGreen &wallet, uint64_t threshold, uint64_t height)
 {

--- a/src/zedwallet/GetInput.cpp
+++ b/src/zedwallet/GetInput.cpp
@@ -10,6 +10,7 @@
 
 #include <zedwallet/Sync.h>
 #include <zedwallet/Tools.h>
+#include <thread>
 
 /* Note: this is not portable, it only works with terminals that support ANSI
    codes (e.g., not Windows) - however! due to the way linenoise-cpp works,

--- a/src/zedwallet/Sync.cpp
+++ b/src/zedwallet/Sync.cpp
@@ -13,6 +13,7 @@
 #include <zedwallet/GetInput.h>
 #include <zedwallet/Tools.h>
 #include <zedwallet/Types.h>
+#include <thread>
 
 void checkForNewTransactions(std::shared_ptr<WalletInfo> walletInfo)
 {

--- a/src/zedwallet/Tools.cpp
+++ b/src/zedwallet/Tools.cpp
@@ -18,6 +18,7 @@
 #include <utilities/Addresses.h>
 #include <utilities/ColouredMsg.h>
 #include <utilities/PasswordContainer.h>
+#include <thread>
 
 void confirmPassword(const std::string &walletPass, const std::string &msg)
 {

--- a/src/zedwallet/Transfer.cpp
+++ b/src/zedwallet/Transfer.cpp
@@ -24,6 +24,7 @@
 #include <wallet/WalletUtils.h>
 #include <zedwallet/Fusion.h>
 #include <zedwallet/Tools.h>
+#include <thread>
 
 bool parseAmount(std::string strAmount, uint64_t &amount)
 {


### PR DESCRIPTION
Hello, developers! I've read requirements that need to use g++-8 but I found a way to compile with g++-12.2.0 and gcc-12.2.0 that installed in my system. The process of compilation had about 10 breaks, but I added some includes for get rid. Here I place all my commands and errors I got or inserted with two spaces at start of line. As result, I build under Linux-6 with gcc-12.2.0 and g++-12.2.0. Here 'v' is alias to vim.


```
##2023-12-11 11:18 install XTE Traaitt.com 0.10.44
wget https://github.com/TRRXITTE/traaitt/archive/refs/tags/0.10.44+-cmd.tar.gz
tar xf 0.10.44+-cmd.tar.gz 
cd traaitt-0.10.44-cmd/
#https://github.com/TRRXITTE/traaitt/blob/master/docs/compile-unix.md
#gcc-8 g++-8
mkdir build && cd build
cmake ..
make
[ 58%] Building CXX object src/CMakeFiles/System.dir/platform/linux/system/Dispatcher.cpp.o
In file included from traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:6:
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.h:49:9: error: ‘uint32_t’ does not name a type
   49 |         uint32_t events;
      |         ^~~~~~~~
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.h:12:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   11 | #include <stack>
  +++ |+#include <cstdint>
   12 | 
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.h:117:25: error: ‘uint8_t’ does not name a type
  117 |         alignas(void *) uint8_t mutex[SIZEOF_PTHREAD_MUTEX_T];
      |                         ^~~~~~~
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:167:18: error: ‘pthread_mutex_destroy’ was not declared in this scope; did you mean ‘pthread_mutexattr_t’?
  167 |         result = pthread_mutex_destroy(reinterpret_cast<pthread_mutex_t *>(this->mutex));
      |                  ^~~~~~~~~~~~~~~~~~~~~
      |                  pthread_mutexattr_t

v ../src/platform/linux/system/Dispatcher.h
  #include <cstdint>

v ../src/platform/linux/system/Dispatcher.cpp
  #include <pthread.h>
  #include <stdio.h>
  #include <stdlib.h>
  #include <unistd.h>
  #define PTHREAD_MUTEX_INITIALIZER { { 0, 0, 0, 0, 0, { 0 } } }
  pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;

make
[ 58%] Building CXX object src/CMakeFiles/System.dir/platform/linux/system/Dispatcher.cpp.o
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:22: warning: "PTHREAD_MUTEX_INITIALIZER" redefined
   22 |   #define PTHREAD_MUTEX_INITIALIZER { { 0, 0, 0, 0, 0, { 0 } } }
      | 
In file included from traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:18:
/usr/include/pthread.h:90: note: this is the location of the previous definition
   90 | #define PTHREAD_MUTEX_INITIALIZER \
      | 
In file included from traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:6:
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.h:50:9: error: ‘uint32_t’ does not name a type
   50 |         uint32_t events;
      |         ^~~~~~~~

make
[ 58%] Building CXX object src/CMakeFiles/System.dir/platform/linux/system/Dispatcher.cpp.o
In file included from traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:6:
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.h:50:9: error: ‘uint32_t’ does not name a type
   50 |         uint32_t events;
      |         ^~~~~~~~
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.h:12:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   11 | #include <stack>
  +++ |+#include <cstdint>

v ..src/platform/linux/system/Dispatcher.h
  #include <stack>
  +#include <cstdint>
make
  [ 58%] Building CXX object src/CMakeFiles/System.dir/platform/linux/system/Dispatcher.cpp.o
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp: In constructor ‘System::{anonymous}::MutextGuard::MutextGuard(pthread_mutex_t&)’:
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:42:32: error: ‘runtime_error’ is not a member of ‘std’
   42 |                     throw std::runtime_error("pthread_mutex_lock failed, " + errorMessage(ret));
      |                                ^~~~~~~~~~~~~
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp: In constructor ‘System::Dispatcher::Dispatcher()’:
  traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:131:20: error: ‘runtime_error’ is not a member of ‘std’
  131 |         throw std::runtime_error("Dispatcher::Dispatcher, " + message);


v ../src/platform/linux/system/Dispatcher.cpp
  #include <pthread.h>
  #include <stdio.h>
  #include <stdlib.h>
  #include <unistd.h>
  #define PTHREAD_MUTEX_INITIALIZER { { 0, 0, 0, 0, 0, { 0 } } }
  pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;

make
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp: In constructor ‘System::{anonymous}::MutextGuard::MutextGuard(pthread_mutex_t&)’:
traaitt-0.10.44-cmd/src/platform/linux/system/Dispatcher.cpp:44:27: error: ‘runtime_error’ was not declared in this scope
   44 |                     throw runtime_error("pthread_mutex_lock failed, " + errorMessage(ret));


v ../src/platform/linux/system/Dispatcher.cpp
  #include <stdexcept>

make
  [ 59%] Building CXX object src/CMakeFiles/System.dir/platform/linux/system/TcpConnection.cpp.o
  traaitt-0.10.44-cmd/src/platform/linux/system/TcpConnection.cpp: In member function ‘System::TcpConnection& System::TcpConnection::operator=(System::TcpConnection&&)’:
  traaitt-0.10.44-cmd/src/platform/linux/system/TcpConnection.cpp:54:28: error: ‘runtime_error’ is not a member of ‘std’
   54 |                 throw std::runtime_error("TcpConnection::operator=, close failed, " + lastErrorMessage());
      |                            ^~~~~~~~~~~~~

v src/platform/linux/system/TcpConnection.cpp
  #include <stdexcept>

make
  [ 67%] Building CXX object src/CMakeFiles/Serialization.dir/serialization/BinaryInputStreamSerializer.cpp.o
  In file included from traaitt-0.10.44-cmd/src/serialization/BinaryInputStreamSerializer.h:9,
                 from traaitt-0.10.44-cmd/src/serialization/BinaryInputStreamSerializer.cpp:6:
  traaitt-0.10.44-cmd/src/serialization/SerializationOverloads.h: In function ‘typename std::enable_if<std::is_pod<_Tp>::value>::type CryptoNote::serializeAsBinary(std::vector<T>&, Common::StringView, ISerializer&)’:
  traaitt-0.10.44-cmd/src/serialization/SerializationOverloads.h:38:28: error: ‘runtime_error’ is not a member of ‘std’
   38 |                 throw std::runtime_error("Invalid blob size given!");
      |                            ^~~~~~~~~~~~~
  traaitt-0.10.44-cmd/src/serialization/SerializationOverloads.h: In function ‘typename std::enable_if<std::is_pod<_Tp>::value>::type CryptoNote::serializeAsBinary(std::__cxx11::list<T>&, Common::StringView, ISerializer&)’:
  traaitt-0.10.44-cmd/src/serialization/SerializationOverloads.h:69:28: error: ‘runtime_error’ is not a member of ‘std’
   69 |                 throw std::runtime_error("Invalid blob size given!");
      |                            ^~~~~~~~~~~~~

v src/serialization/SerializationOverloads.h
  #include <stdexcept>

make
[ 69%] Building CXX object src/CMakeFiles/Serialization.dir/serialization/KVBinaryOutputStreamSerializer.cpp.o
traaitt-0.10.44-cmd/src/serialization/KVBinaryOutputStreamSerializer.cpp: In function ‘void {anonymous}::writeElementName(Common::IOutputStream&, Common::StringView)’:
traaitt-0.10.44-cmd/src/serialization/KVBinaryOutputStreamSerializer.cpp:34:35: error: ‘numeric_limits’ is not a member of ‘std’
   34 |         if (name.getSize() > std::numeric_limits<uint8_t>::max())
      |                                   ^~~~~~~~~~~~~~
traaitt-0.10.44-cmd/src/serialization/KVBinaryOutputStreamSerializer.cpp:34:57: error: expected primary-expression before ‘>’ token
   34 |         if (name.getSize() > std::numeric_limits<uint8_t>::max())
      |                                                         ^
traaitt-0.10.44-cmd/src/serialization/KVBinaryOutputStreamSerializer.cpp:34:60: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   34 |         if (name.getSize() > std::numeric_limits<uint8_t>::max())
      |                                                            ^~~
      |                                                            std::max
In file included from /usr/include/c++/12/algorithm:61,

v src/serialization/KVBinaryOutputStreamSerializer.cpp
  #include <limits>
make
  [ 85%] Building CXX object src/CMakeFiles/Transfers.dir/transfers/BlockchainSynchronizer.cpp.o
  traaitt-0.10.44-cmd/src/transfers/BlockchainSynchronizer.cpp: In member function ‘void CryptoNote::BlockchainSynchronizer::processBlocks(GetBlocksResponse&)’:
  traaitt-0.10.44-cmd/src/transfers/BlockchainSynchronizer.cpp:646:43: error: ‘sleep_for’ is not a member of ‘std::this_thread’
  646 |                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
      |                                           ^~~~~~~~~

v src/transfers/BlockchainSynchronizer.cpp
  #include<thread>
make
  [ 95%] Building CXX object src/CMakeFiles/zedwallet.dir/zedwallet/Fusion.cpp.o
  traaitt-0.10.44-cmd/src/zedwallet/Fusion.cpp: In function ‘bool optimize(CryptoNote::WalletGreen&, uint64_t, uint64_t)’:
  traaitt-0.10.44-cmd/src/zedwallet/Fusion.cpp:143:23: error: ‘sleep_for’ is not a member of ‘std::this_thread’
  143 |     std::this_thread::sleep_for(std::chrono::seconds(1));
v src/zedwallet/Fusion.cpp
  15:#include <thread>
make
  traaitt-0.10.44-cmd/src/zedwallet/GetInput.cpp: In function ‘std::string getInputAndWorkInBackground(const std::vector<CharType>&, std::string, bool, std::shared_ptr<WalletInfo>)’:
  traaitt-0.10.44-cmd/src/zedwallet/GetInput.cpp:85:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
   85 |             std::this_thread::sleep_for(std::chrono::milliseconds(50));
v src/zedwallet/GetInput.cpp
  13:#include <thread>
make
  traaitt-0.10.44-cmd/src/zedwallet/Sync.cpp:182:27: error: ‘sleep_for’ is not a member of ‘std::this_thread’
  182 |         std::this_thread::sleep_for(std::chrono::seconds(waitSeconds));
v src/zedwallet/Sync.cpp
  16:#include <thread>
make
  traaitt-0.10.44-cmd/src/zedwallet/Tools.cpp:307:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
  307 |             std::this_thread::sleep_for(std::chrono::seconds(1));
v src/zedwallet/Tools.cpp
  21:#include <thread>
v src/zedwallet/Transfer.cpp
  27:#include <thread>
make
##finished fine
./src/XTEnetwork --data-dir blockchain_data
##works!



```